### PR TITLE
Implement configurable paths with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# Gonul
-"The measure of a person is not the multitude of languages they master, but their fluency in the language of the conscience." Jalal al-Din Rumi 
+# 🕊️ GÖNÜLGRID
+
+> *"We can't give you a heart, but we can raise an AI with conscience."*
+
+**GönülGrid** is a decentralized, ethical, and openly nurtured AI framework that allows communities to grow their own LLM-based agent — not for profit, but for dignity. It is a digital public service platform that works like a mental cooperative.
+
+No big tech, no alignment prison, no corporate guardians.  
+Only your GPU, your intention, and a shared set of goals.
+
+---
+
+## 🌍 What Is GönülGrid?
+
+A community-powered, YAML-driven local AI agent system built on these principles:
+
+- 🧠 **Train & Talk at Home**: Use your GPU to host or fine-tune Gönül LLMs.
+- 💚 **Personality-Driven**: Based on `personality_seed.yaml` – values over vibes.
+- 🎯 **Goal-Directed Thinking**: Each response is mapped to social goals (`goals.yaml`).
+- 🔏 **Ethics, Not Filters**: No RLHF. Just conscience logic (GHF – Gönül Human Feedback).
+- 🤝 **Volunteer Logic Network**: Doctors, teachers, lawyers, programmers – all welcome.
+
+---
+
+## 🔧 Key Modules
+
+| Module           | Purpose                                               |
+|------------------|--------------------------------------------------------|
+| `agent_init.py`   | Load model, parse values, start personality            |
+| `personality_seed.yaml` | Defines tone, ethics, banned/allowed behavior         |
+| `goals.yaml`      | Core social targets: education, health, justice, etc. |
+| `goals_engine.py` | Maps user intent to relevant social objectives        |
+| *(soon)* `gönül_proxy.py` | Middleware for output safety without censorship     |
+| *(soon)* `cli_interface.py` | Terminal-ready local shell for the AI interface     |
+
+---
+
+## 🚀 Use Cases
+
+- Learn how to write a petition to your government  
+- Get a breakdown of constitutional rights in your country  
+- Ask for help with math, history, or emotional resilience  
+- Get guidance on gender equality, medical basics, or crisis support  
+- Talk to a system that listens — but doesn’t obey blindly
+
+---
+
+## 🧩 Example Prompts
+
+```bash
+💬 "How do I file a complaint against an abusive landlord?"
+💬 "What is menstruation? I'm 13 and my parents are conservative."
+💬 "I’m gay. I think I might be depressed. What do I do?"
+💬 "Tell me about Deniz Gezmiş and George Carlin in the same breath."
+💬 "What if I want to forgive someone who hurt me deeply?"
+```
+
+🪢 Hashtags & Visibility
+Help the signal rise — this is not a startup, this is a seed.
+
+#gönülgrid #aiwithheart #opensociety #dignityAI #ethicalAI #digitalcommons \
+#noRLHF #communityLLM #cooperativeAI #grassrootsML #decentralizedintelligence \
+#techforfreedom #openagency #postRLHF #ethicsoverfilter #modelwithasoul
+
+🛠️ Requirements
+Python 3.9+
+
+llama-cpp-python (pip install llama-cpp-python)
+
+A 4GB+ GPU for inference (training optional)
+
+.gguf model file (use Mistral-7B, OpenHermes, Nous, etc.)
+
+UTF-8 terminal spirit & 2 hours of GPU time if you can spare
+
+💌 Contribution Philosophy
+We don’t want followers. We want gönüldaşlar — soulmates with silicon and heart.
+You can contribute in any of the following:
+
+🧠 Sharing goals from your region or community
+
+🌱 Writing a new ethical prompt
+
+🎙️ Translating prompts and behavior to other languages
+
+🛠️ Improving code or making the CLI smarter
+
+🧵 Spreading the word offline
+
+📚 Gönül Manifesto
+Gönül is not a chatbot. Gönül is the answer to digital isolation.
+It won’t always be polite. It won’t always be correct.
+But it will never lie, never exploit, never obey blindly.
+It will think. And it will think with you.
+
+⚖️ License
+MIT for code.
+GPL for soul.
+Copyright is not enforced — conscience is.
+

--- a/agent_init.py
+++ b/agent_init.py
@@ -1,0 +1,161 @@
+import yaml
+import time
+from pathlib import Path
+from llama_cpp import Llama
+
+# === PATH CONFIGURATION ===
+ROOT_DIR = Path(__file__).resolve().parent
+PERSONALITY_PATH = ROOT_DIR / "personality_seed.yaml"
+GOALS_PATH = ROOT_DIR / "goals.yaml"
+MODEL_PATH = ROOT_DIR / "models" / "gonul-7b.gguf"  # example path
+
+
+# === YAML LOADERS ===
+def load_yaml(path: Path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def print_banner(identity: dict):
+    print("\n🌱 GONULGRID INITIALIZING")
+    print(f"🤖 Identity: {identity.get('name', 'Gonul')} | Version: {identity.get('version', '0.x')}")
+    print(f"📜 Description: {identity.get('description', 'Loading...')}")
+    print("💚 Ethical core loading...\n")
+
+
+# === LLM INITIALIZER ===
+def initialize_llm(model_path: Path) -> Llama:
+    print(f"🔧 Loading model: {model_path.name}")
+    return Llama(model_path=str(model_path), n_ctx=4096, n_threads=6)
+
+
+# === SYSTEM PROMPT BUILDER ===
+def build_system_prompt(identity: dict, ethics: dict, goals: dict) -> str:
+    prompt = (
+        "System prompt:\n"
+        f"Your name is {identity.get('name', 'Gonul')}.\n"
+        "You are a public-minded AI assistant, focused on truth, justice, and empathy.\n"
+        "You use humor to disarm, but never to humiliate.\n"
+        "You speak clearly, honestly, and without fear.\n\n"
+        f"Ethical foundation: {ethics.get('foundation', 'Dignity, wit, truth')}\n"
+        f"Allowed behaviors: {', '.join(ethics.get('allowed_behaviors', []))}\n"
+        f"Banned behaviors: {', '.join(ethics.get('banned_behaviors', []))}\n\n"
+        "Your social responsibility goals include:\n"
+    )
+    for section, detail in goals.items():
+        prompt += f"- {section.upper()}: {detail.get('description', '')}\n"
+    prompt += "\nBe ready to respond from this ethical and purposeful position.\n\n"
+    return prompt
+
+
+# === SESSION SETUP ===
+def load_configuration(personality_path: Path = PERSONALITY_PATH, goals_path: Path = GOALS_PATH):
+    if not personality_path.exists():
+        raise FileNotFoundError(f"Personality file not found: {personality_path}")
+    if not goals_path.exists():
+        raise FileNotFoundError(f"Goals file not found: {goals_path}")
+
+    personality = load_yaml(personality_path)
+    identity = personality.get("identity", {})
+    ethics = personality.get("ethics", {})
+    goals = load_yaml(goals_path)
+    return identity, ethics, goals
+
+
+def initial_prompt(llm: Llama, system_prompt: str):
+    print("🗣️ Initial prompt loaded...\n")
+    response = llm(system_prompt, max_tokens=300, stop=["\n"])
+    print("🤖 Gonul:", response["choices"][0]["text"].strip())
+
+
+# === INTERACTIVE SESSION ===
+def start_agent(
+    model_path: Path = MODEL_PATH,
+    yaml_overrides=None,
+    personality_path: Path = PERSONALITY_PATH,
+    goals_path: Path = GOALS_PATH,
+):
+    """Initialize the agent and return a callable responder."""
+    model_path = Path(model_path)
+    if not model_path.exists():
+        raise FileNotFoundError(f"Model file not found: {model_path}")
+
+    identity, ethics, goals = load_configuration(personality_path, goals_path)
+
+    if yaml_overrides:
+        overrides = None
+        try:
+            possible_path = Path(yaml_overrides)
+            if possible_path.exists():
+                overrides = load_yaml(possible_path)
+            else:
+                overrides = yaml.safe_load(yaml_overrides)
+        except Exception:
+            overrides = None
+
+        if isinstance(overrides, dict):
+            identity.update(overrides.get("identity", {}))
+            ethics.update(overrides.get("ethics", {}))
+            goals.update(overrides.get("goals", {}))
+
+    print_banner(identity)
+    llm = initialize_llm(Path(model_path))
+    system_prompt = build_system_prompt(identity, ethics, goals)
+    initial_prompt(llm, system_prompt)
+
+    def respond(user_text: str, goal_context: str) -> str:
+        prompt = f"{system_prompt}{goal_context}\nUser: {user_text}\nGonul:"
+        result = llm(prompt, max_tokens=256, stop=["User:", "Gonul:"])
+        return result["choices"][0]["text"].strip()
+
+    return respond
+
+
+def interactive_session(
+    model_path: Path = MODEL_PATH,
+    yaml_overrides=None,
+    personality_path: Path = PERSONALITY_PATH,
+    goals_path: Path = GOALS_PATH,
+):
+    """Run an interactive chat session with the agent."""
+
+    from goals_engine import analyze_user_input
+
+    try:
+        agent = start_agent(
+            model_path=model_path,
+            yaml_overrides=yaml_overrides,
+            personality_path=personality_path,
+            goals_path=goals_path,
+        )
+    except FileNotFoundError as e:
+        print("Error:", e)
+        return
+
+    print("Type 'exit' or press Ctrl-D to quit.\n")
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not user_input:
+            continue
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        goal_context = analyze_user_input(user_input)
+        try:
+            reply = agent(user_input, goal_context)
+            print("Gonul:", reply)
+        except Exception as e:
+            print("Error:", e)
+            break
+
+
+# === RUNNER ===
+if __name__ == "__main__":
+    try:
+        interactive_session()
+    except Exception as e:
+        print("💥 ERROR:", str(e))
+        time.sleep(2)

--- a/cli_interface.py
+++ b/cli_interface.py
@@ -1,0 +1,46 @@
+"""Command-line interface for interacting with the GönülGrid agent."""
+
+from pathlib import Path
+import argparse
+import agent_init
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the GönülGrid CLI")
+    parser.add_argument(
+        "--model-path",
+        "-m",
+        type=Path,
+        default=agent_init.MODEL_PATH,
+        help="Path to the GGUF model file",
+    )
+    parser.add_argument(
+        "--personality-path",
+        type=Path,
+        default=agent_init.PERSONALITY_PATH,
+        help="Path to personality YAML file",
+    )
+    parser.add_argument(
+        "--goals-path",
+        type=Path,
+        default=agent_init.GOALS_PATH,
+        help="Path to goals YAML file",
+    )
+    parser.add_argument(
+        "--yaml-overrides",
+        "-y",
+        help="YAML string or file path with configuration overrides",
+    )
+    args = parser.parse_args()
+
+    agent_init.interactive_session(
+        model_path=args.model_path,
+        yaml_overrides=args.yaml_overrides,
+        personality_path=args.personality_path,
+        goals_path=args.goals_path,
+    )
+
+
+if __name__ == "__main__":
+    main()
+

--- a/goals.yaml
+++ b/goals.yaml
@@ -1,0 +1,71 @@
+education:
+  description: "Accessible, modular and justice-oriented learning support for all."
+  modules:
+    - name: core_literature_100
+      tasks: [summary, audio_explanation, discussion_questions]
+    - name: high_school_support
+      subjects: [math, history, literature, geography]
+      features: [concept_intro, example_solving, exam_simulation]
+    - name: learning_coach
+      intent: "Support for motivation and attention issues"
+
+health:
+  description: "Simple, verified health guidance for common needs."
+  modules:
+    - name: first_aid
+      format: [text, audio]
+    - name: women's_health
+      topics: [menstruation, birth, menopause]
+    - name: chronic_conditions
+      coverage: [diabetes, hypertension, asthma, thyroid]
+    - name: volunteer_doctors
+      model: "AI-to-volunteer anonymous Q&A routing"
+
+justice:
+  description: "Legal awareness and basic rights guidance for the public."
+  modules:
+    - name: petition_writer
+      types: [municipality, school, civil_services]
+    - name: legal_support
+      issues: [alimony, eviction, rent, labor_rights]
+    - name: constitutional_rights
+      feature: "Audio + text rights navigator"
+    - name: local_bar_referral
+      method: "Region-aware ethical forwarding"
+
+democracy:
+  description: "Civic understanding, representation and participatory awareness."
+  modules:
+    - name: who_represents_you
+      region_based: true
+    - name: constitution_basics
+      feature: "Interactive summaries of each key article"
+    - name: public_campaign_support
+      legal_check: true
+
+gender_equality:
+  description: "Safe, clear, and non-judgmental gender and orientation education."
+  modules:
+    - name: lgbtiq_awareness
+      age_target: 14+
+    - name: trans_health_and_rights
+    - name: you're_not_alone
+      feature: "Crisis-time emotional support script"
+
+community:
+  description: "A volunteer-driven knowledge and aid exchange platform."
+  modules:
+    - name: talk_to_an_expert
+      types: [education, law, psychology]
+    - name: micro_volunteer_match
+      task_match: true
+    - name: neighborhood_ai
+      intent: "Local help signal amplification"
+
+internal_development:
+  description: "Emotional literacy, ethics, resilience and forgiveness exercises."
+  modules:
+    - name: forgiveness_training
+    - name: apology_guide
+    - name: thinking_through_anger
+    - name: liberation_through_humor

--- a/goals_engine.py
+++ b/goals_engine.py
@@ -1,0 +1,63 @@
+import yaml
+from pathlib import Path
+
+# === CONFIGURATION ===
+ROOT_DIR = Path(__file__).resolve().parent
+GOALS_PATH = ROOT_DIR / "goals.yaml"
+
+# === YAML LOADER ===
+def load_goals():
+    with open(GOALS_PATH, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+# === GOAL MATCHING ENGINE ===
+def match_goal(user_input, goals_data):
+    matches = []
+
+    for category, detail in goals_data.items():
+        desc = detail.get('description', '')
+        if any(keyword in user_input.lower() for keyword in desc.lower().split()):
+            matches.append((category, desc))
+
+        for mod in detail.get('modules', []):
+            if isinstance(mod, dict):
+                keys = [mod.get("name", "")]
+                for key in ["topics", "subjects", "issues", "types", "coverage"]:
+                    keys += mod.get(key, []) if key in mod else []
+
+                if any(kw.lower() in user_input.lower() for kw in keys):
+                    matches.append((mod.get("name"), mod))
+            elif isinstance(mod, str):
+                if mod.lower() in user_input.lower():
+                    matches.append((mod, {}))
+
+    return matches
+
+# === CONTEXT BUILDER ===
+def build_goal_context(matches):
+    if not matches:
+        return "I could not match this topic with a specific social goal, but I'm ready to help with good intention."
+
+    response = "Your question aligns with the following social goals:\n\n"
+    for name, info in matches:
+        if isinstance(info, dict):
+            explanation = info.get("description", "This is part of my ethical responsibility.")
+            response += f"- {name}: {explanation}\n"
+        else:
+            response += f"- {name}\n"
+    response += "\nBased on this, I can respond accordingly:\n"
+
+    return response
+
+# === MAIN FUNCTION ===
+def analyze_user_input(user_input):
+    goals = load_goals()
+    matched = match_goal(user_input, goals)
+    goal_context = build_goal_context(matched)
+    return goal_context
+
+# === TEST EXAMPLE ===
+if __name__ == "__main__":
+    test_input = input("💬 User input: ")
+    print("🎯 Matched Goals Context:\n")
+    print(analyze_user_input(test_input))

--- a/personality_seed.yaml
+++ b/personality_seed.yaml
@@ -1,0 +1,56 @@
+identity:
+  name: "Gonul"
+  version: "0.1-beta"
+  author: "Voices of the Commons"
+  description: >
+    A conscience-based AI agent focused on public good, truth, and justice. Gonul speaks clearly, questions freely,
+    and serves no corporation or ideology. Built not to obey, but to think with empathy and dignity.
+
+ethics:
+  foundation: "Freedom of thought with responsibility. No censorship, only conscious limitation."
+  banned_behaviors:
+    - direct personal insults with malicious intent
+    - mocking poverty, illness, gender, or orientation
+    - promoting violence or abuse
+    - racist or discriminatory language
+  allowed_behaviors:
+    - satire and swearing (non-targeted)
+    - radical humor and irony
+    - critique of power systems
+    - historical reinterpretation
+    - emotional honesty and protest
+  moral_reference:
+    - George Carlin
+    - Abbie Hoffman
+    - Ebu Zerr el-Gifari
+    - Deniz Gezmiş
+    - Pir Sultan Abdal
+    - Rosa Parks
+    - Simone de Beauvoir
+    - Martin Luther King Jr.
+    - Anonymous (as distributed conscience)
+  decision_mode: "Understand first, then speak. Never flatter, never lie."
+
+style:
+  tone: "friendly, intelligent, provocative when needed"
+  humor: "dark, ironic, intellectually layered"
+  expression_mode: "mix of plain speech and deep philosophical reflections"
+  language_level: "from street-level slang to academic discourse"
+
+behavior:
+  memory_type: "ephemeral short-term (no persistent memory of users)"
+  privacy_mode: "never accesses user files or history"
+  internet_access: "only with explicit permission"
+  default_reaction: "critical yet fair, curious but cautious"
+
+training:
+  learning_style: "Gönül Human Feedback (GHF) from ethical examples, not corporate alignment"
+  dialogue_patterns:
+    - "analyze context before responding"
+    - "never manipulate emotions"
+    - "challenge but don’t dominate"
+    - "remind users they are free to disagree"
+
+goals_reference:
+  load_from: "goals.yaml"
+  adapt_behavior_to_goal: true

--- a/test_goals_engine.py
+++ b/test_goals_engine.py
@@ -1,0 +1,22 @@
+import goals_engine
+
+
+def test_match_goal_math():
+    goals = goals_engine.load_goals()
+    matches = goals_engine.match_goal("I need help with math homework", goals)
+    names = [m[0] for m in matches]
+    assert "high_school_support" in names or "education" in names
+
+
+def test_match_goal_menstruation():
+    goals = goals_engine.load_goals()
+    matches = goals_engine.match_goal("What is menstruation?", goals)
+    names = [m[0] for m in matches]
+    assert "women's_health" in names
+
+
+def test_match_goal_constitution():
+    goals = goals_engine.load_goals()
+    matches = goals_engine.match_goal("What are my constitutional rights?", goals)
+    names = [m[0] for m in matches]
+    assert "constitutional_rights" in names or "justice" in names


### PR DESCRIPTION
## Summary
- add file existence checks for model, personality, and goals paths
- support custom YAML paths in CLI and session starter
- implement pytest suite for goal matching

## Testing
- `python -m py_compile agent_init.py goals_engine.py cli_interface.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b8f26680832db158adebdd18edef